### PR TITLE
Replace JGit Repository.getRef() with Repository.findRef()

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/pretestedintegration/integration/scm/git/TestUtilsFactory.java
+++ b/src/test/java/org/jenkinsci/plugins/pretestedintegration/integration/scm/git/TestUtilsFactory.java
@@ -101,7 +101,7 @@ public class TestUtilsFactory {
     // https://github.com/centic9/jgit-cookbook/blob/master/src/main/java/org/dstadler/jgit/api/WalkRev.java
     public static int countCommitsOnBranch(Git git, String branch) throws IOException {
 
-        Ref head = git.getRepository().getRef(branch);
+        Ref head = git.getRepository().findRef(branch);
         RevWalk walk = new RevWalk(git.getRepository());
         RevCommit commit = walk.parseCommit(head.getObjectId());
         walk.markStart(commit);
@@ -472,7 +472,7 @@ public class TestUtilsFactory {
         boolean firstCommit = true;
         for (TestCommit commit : commits) {
             if (!commit.branch.equals("master")) {
-                boolean branchExists = git.getRepository().getRef(commit.branch) != null;
+                boolean branchExists = git.getRepository().findRef(commit.branch) != null;
                 if (!branchExists) {
                     git.branchCreate().setName(commit.branch).call();
                 }


### PR DESCRIPTION
JGit 5.0 (or earlier) deprecated the Repository.getRef(String) method and replaced it with two methods, [Repository.findRef(String)](https://download.eclipse.org/jgit/site/5.2.0.201812061821-r/apidocs/org/eclipse/jgit/lib/Repository.html#findRef-java.lang.String-) and [Repository.exactRef(String)](https://download.eclipse.org/jgit/site/5.2.0.201812061821-r/apidocs/org/eclipse/jgit/lib/Repository.html#exactRef-java.lang.String-).

JGit 5.2 removed the deprecated method.

Git client plugin 3.0 will bundle JGit 5.2 or later.  Rather than risk runtime and compilation failures when using git client plugin 3.0 and later, switch from the deprecated methods to the new methods.

Without this change, this plugin will be **broken** with the release of git client plugin 3.0.